### PR TITLE
add route to update item status enum

### DIFF
--- a/src/server/controller/items.js
+++ b/src/server/controller/items.js
@@ -43,6 +43,40 @@ function getItems(req, res) {
   });
 }
 
+function updateItemStatus(req, res) {
+  const safeWords = ['LISTED', 'VERIFIED', 'PAID', 'READY_FOR_PICKUP', 'PICKED_UP'];
+  
+  if (req.body.newStatus && req.body.itemIds && Array.isArray(req.body.itemIds)) {
+    if (safeWords.includes(req.body.newStatus)) {
+      if (req.body.itemIds.length > 0) {
+        let query = `UPDATE items SET status='${req.body.newStatus}' WHERE 1=1 AND (`;
+        req.body.itemIds.forEach(id => {
+          query += `item_id=${id} OR `;
+        });
+        query += `1=0);`;
+        conn.query(query, (err, rows) => {
+          if (err) {
+            console.log(err);
+            res.status(400).send();
+          } else {
+            res.status(200).json({
+              msg: `Item status updated to ${req.body.newStatus}`,
+            });
+          }
+        });
+      }
+    } else {
+      res.status(400).json({
+        error: 'Invalid status type'
+      })
+    }
+  } else {
+    res.status(400).json({
+      error: 'invalid request body'
+    });
+  }
+}
+
 function verifyItems(req, res) {
   if (req.body.itemIds.length > 0) {
     let query = "UPDATE items SET status='VERIFIED' WHERE 1=1 AND (";
@@ -107,4 +141,4 @@ function pickupConfirmation(req, res) {
   }
 }
 
-export default { getItems, verifyItems, readyForPickup, pickupConfirmation };
+export default { getItems, verifyItems, readyForPickup, pickupConfirmation, updateItemStatus };

--- a/src/server/routes/items.js
+++ b/src/server/routes/items.js
@@ -11,6 +11,10 @@ router.post("/verify", (req, res) => {
   controller.verifyItems(req, res);
 });
 
+router.post("/updateItemStatus", (req, res) => {
+  controller.updateItemStatus(req, res);
+});
+
 router.post("/pickup/ready", (req, res) => {
   controller.readyForPickup(req, res);
 });


### PR DESCRIPTION
Decided that instead of having separate routes for updating the item status enum (which is hard to maintain and update if we ever change an enum), we should have a single route `api/items/updateItemStatus` that takes in the following request body:

```
{
  "itemIds": item Ids to be updated,
  "newStatus": status enum
}
```
and updates the status of passed in item ids. 