### PR TITLE
captureTransaction route

### DIFF
--- a/src/server/controller/donate.js
+++ b/src/server/controller/donate.js
@@ -48,7 +48,7 @@ async function captureTransaction(req, res) {
       }
 
       // Create donation entry
-      donationId = await donationHelpers.insertDonationIntoDB(
+      const donationId = await donationHelpers.insertDonationIntoDB(
         donorInfo.email, donorInfo.firstName, donorInfo.lastName,
         amount, bankTransferFee, serviceFee,
         null, null, null, 'stripe',
@@ -64,6 +64,7 @@ async function captureTransaction(req, res) {
         donorCountry = payment_method_details.card.country;
       } catch (error) {
         console.log(`chargeTransaction: stripe error: ${error}`);
+        donationHelpers.removeDonationFromDB(donationId);
         return res.status(500).send({ duetErrorCode: 'StripeError', error });
       }
 
@@ -123,6 +124,7 @@ async function captureTransaction(req, res) {
         paypalCaptureResp = await paypalHelpers.capturePayPalOrder(paypalOrderId);
       } catch (error) {
         console.log(`chargeTransaction: paypal error: ${error}`);
+        donationHelpers.removeDonationFromDB(donationId);
         return res.status(500).send({ duetErrorCode: 'PayPalError', error });
       }
       const firstName = paypalCaptureResp.payer.name.given_name;

--- a/src/server/controller/donate.js
+++ b/src/server/controller/donate.js
@@ -118,11 +118,17 @@ async function captureTransaction(req, res) {
       }
 
       // Capture paypal order
-      const details = await paypalHelpers.capturePayPalOrder(paypalOrderId);
-      const firstName = details.payer.name.given_name;
-      const lastName = details.payer.name.surname;
-      const email = details.payer.email_address;
-      const donorCountry = details.payer.address.country_code;
+      let paypalCaptureResp;
+      try {
+        paypalCaptureResp = await paypalHelpers.capturePayPalOrder(paypalOrderId);
+      } catch (error) {
+        console.log(`chargeTransaction: paypal error: ${error}`);
+        return res.status(500).send({ duetErrorCode: 'PayPalError', error });
+      }
+      const firstName = paypalCaptureResp.payer.name.given_name;
+      const lastName = paypalCaptureResp.payer.name.surname;
+      const email = paypalCaptureResp.payer.email_address;
+      const donorCountry = paypalCaptureResp.payer.address.country_code;
 
       // Create donation entry
       const donationId = await donationHelpers.insertDonationIntoDB(

--- a/src/server/routes/donate.js
+++ b/src/server/routes/donate.js
@@ -5,10 +5,12 @@ import { passport } from './../util/auth.js';
 const router = express.Router();
 
 router.get("/", controller.getDonation);
+
+router.post("/captureTransaction", controller.captureTransaction);
+
+// TODO: deprecate all these
 router.post("/verifyTransaction", controller.verifyNewTransaction);
 router.post("/cancelTransaction", controller.cancelTransaction);
-router.post("/paid", controller.processSuccessfulTransaction); //TODO: phase this out later
-
 router.post("/chargeTransaction", controller.chargeTransaction);
 router.post("/processTransaction", controller.processSuccessfulTransaction);
 

--- a/src/server/util/donationHelpers.js
+++ b/src/server/util/donationHelpers.js
@@ -126,6 +126,17 @@ async function insertDonationIntoDB(
   }
 }
 
+async function removeDonationFromDB(donationId) {
+  try {
+    const conn = await config.dbInitConnectPromise();
+    await conn.query("DELETE FROM donations where donation_id=?", [donationId]);
+    console.log(`Successfully removed donation ${donationId} from database`);
+  } catch (err) {
+    errorHandler.handleError(err, "donationHelpers/removeDonationFromDb");
+    throw err;
+  }
+}
+
 async function setDonorCountry(donationId, donorCountry) {
   try {
     const conn = await config.dbInitConnectPromise();
@@ -186,8 +197,9 @@ export default {
   sqlRowToDonationObj,
   getDonationObjFromDonationId,
 
-  // insert donation/subscription
+  // insert/remove donation/subscription
   insertDonationIntoDB,
+  removeDonationFromDB,
   insertSubscriptionIntoDB,
 
   // update existing donation

--- a/src/server/util/donationHelpers.js
+++ b/src/server/util/donationHelpers.js
@@ -126,6 +126,30 @@ async function insertDonationIntoDB(
   }
 }
 
+async function setDonorCountry(donationId, donorCountry) {
+  try {
+    const conn = await config.dbInitConnectPromise();
+    await conn.query("UPDATE donations SET donor_country=? WHERE donation_id=?",
+      [donorCountry, donationId]);
+    console.log(`donationHelpers/setDonationDonorCountry: successfully set donorCountry to ${donorCountry} for donation ${donationId}`);
+  } catch (err) {
+    errorHandler.handleError(err, "donationHelpers/setDonationDonorCountry");
+    throw err;
+  }
+}
+
+async function setStripeOrderId(donationId, stripeOrderId) {
+  try {
+    const conn = await config.dbInitConnectPromise();
+    await conn.query("UPDATE donations SET stripe_order_id=? WHERE donation_id=?",
+      [stripeOrderId, donationId]);
+    console.log(`donationHelpers/setStripeOrderId: successfully set stripeOrderId to ${stripeOrderId} for donation ${donationId}`);
+  } catch (err) {
+    errorHandler.handleError(err, "donationHelpers/setStripeOrderId");
+    throw err;
+  }
+}
+
 async function insertSubscriptionIntoDB(email, firstName, lastName, amount, bankTransferFee, serviceFee, country, 
   paypalSubscriptionId, stripeSubscriptionId, paymentMethod) {
   // Insert subscription info into DB, return insert ID
@@ -165,6 +189,10 @@ export default {
   // insert donation/subscription
   insertDonationIntoDB,
   insertSubscriptionIntoDB,
+
+  // update existing donation
+  setDonorCountry,
+  setStripeOrderId,
 
   // other helpers
   markItemAsDonated,

--- a/src/server/util/paypalHelpers.js
+++ b/src/server/util/paypalHelpers.js
@@ -123,19 +123,44 @@ async function sendNecessaryPayoutsForItemIds(itemIds) {
 
 // ---------- ORDERS ---------- //
 
+// async function capturePayPalOrder(paypalOrderId) {
+//   try {
+//     return new Promise(function (resolve, reject) {
+//       paypal.order.capture(paypalOrderId, {}, function (error, captureResp) {
+//         if (error) {
+//           console.log(`paypalHelpers/capturePayPalOrder error: ${error.response}`);
+//           reject(error);
+//         } else {
+//           console.log(`paypalHelpers/capturePayPalOrder success: ${JSON.stringify(captureResp)}`);
+//           resolve(captureResp);
+//         }
+//       });
+//     });
+//   } catch (err) {
+//     errorHandler.handleError(err, "paypalHelpers/capturePayPalOrder");
+//     throw err;
+//   }
+// }
+
 async function capturePayPalOrder(paypalOrderId) {
   try {
-    return new Promise(function (resolve, reject) {
-      paypal.order.capture(paypalOrderId, {}, function (error, captureResp) {
-        if (error) {
-          console.log(`paypalHelpers/capturePayPalOrder error: ${error.response}`);
-          reject(error);
-        } else {
-          console.log(`paypalHelpers/capturePayPalOrder success: ${JSON.stringify(captureResp)}`);
-          resolve(captureResp);
-        }
-      });
-    });
+    const res = await rp(
+      `${process.env.PAYPAL_API_URL}/v2/checkout/orders/${paypalOrderId}/capture`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Prefer: 'return=representation'
+        },
+        auth: {
+          user: process.env.PAYPAL_CLIENT_ID,
+          password: process.env.PAYPAL_CLIENT_SECRET
+        },
+        json: true
+      }
+    );
+    return res;
   } catch (err) {
     errorHandler.handleError(err, "paypalHelpers/capturePayPalOrder");
     throw err;

--- a/src/server/util/paypalHelpers.js
+++ b/src/server/util/paypalHelpers.js
@@ -128,10 +128,10 @@ async function capturePayPalOrder(paypalOrderId) {
     return new Promise(function (resolve, reject) {
       paypal.order.capture(paypalOrderId, {}, function (error, captureResp) {
         if (error) {
-          console.log(error.response);
+          console.log(`paypalHelpers/capturePayPalOrder error: ${error.response}`);
           reject(error);
         } else {
-          console.log(captureResp);
+          console.log(`paypalHelpers/capturePayPalOrder success: ${captureResp}`);
           resolve(captureResp);
         }
       });

--- a/src/server/util/paypalHelpers.js
+++ b/src/server/util/paypalHelpers.js
@@ -131,7 +131,7 @@ async function capturePayPalOrder(paypalOrderId) {
           console.log(`paypalHelpers/capturePayPalOrder error: ${error.response}`);
           reject(error);
         } else {
-          console.log(`paypalHelpers/capturePayPalOrder success: ${captureResp}`);
+          console.log(`paypalHelpers/capturePayPalOrder success: ${JSON.stringify(captureResp)}`);
           resolve(captureResp);
         }
       });

--- a/src/server/util/paypalHelpers.js
+++ b/src/server/util/paypalHelpers.js
@@ -121,6 +121,27 @@ async function sendNecessaryPayoutsForItemIds(itemIds) {
   }
 }
 
+// ---------- ORDERS ---------- //
+
+async function capturePayPalOrder(paypalOrderId) {
+  try {
+    return new Promise(function (resolve, reject) {
+      paypal.order.capture(paypalOrderId, {}, function (error, captureResp) {
+        if (error) {
+          console.log(error.response);
+          reject(error);
+        } else {
+          console.log(captureResp);
+          resolve(captureResp);
+        }
+      });
+    });
+  } catch (err) {
+    errorHandler.handleError(err, "paypalHelpers/capturePayPalOrder");
+    throw err;
+  }
+}
+
 // ---------- BALANCES ---------- //
 
 async function getPayPalBalance(currencyCode) {
@@ -298,6 +319,9 @@ export default {
   getPayPalPayoutInfoForItemIds,
   sendPayout,
   sendNecessaryPayoutsForItemIds,
+
+  // orders
+  capturePayPalOrder,
 
   // balances
   checkPayPalEuroBalanceAndSendEmailIfLow,


### PR DESCRIPTION
* Merge `verifyTransaction`, `chargeTransaction`, and `processTransaction` into a single `captureTransaction` route
* Capture paypal transaction on the backend: https://github.com/paypal/PayPal-node-SDK/blob/master/samples/order/capture.js. The documentation on `paypal.order.capture()` is pretty poor, so the new `paypalHelpers/capturePayPalOrder` function may break upon initial testing

@Raghav-Maheshwari Todo: Test this with the frontend, because it's hard to test this PR alone in the backend