### PR TITLE
prioritize instance_tooltip for tooltipDescription

### DIFF
--- a/src/server/util/itemHelpers.js
+++ b/src/server/util/itemHelpers.js
@@ -13,7 +13,7 @@ function sqlRowToItemObj(row) {
     price: Number(row.price_euros),
     checkoutPriceUsd: row.checkout_price_usd ? Number(row.checkout_price_usd) : null,
     comment: row.comment,
-    tooltipDescription: row.tooltip_description,
+    tooltipDescription: row.instance_tooltip || row.tooltip_description,
     itemInstanceTags: row.item_instance_tags ? row.item_instance_tags.split(",") : [],
     itemTypeTags: row.item_type_tags ? row.item_type_tags.split(",") : [],
     storeId: row.store_id,


### PR DESCRIPTION
* Create a new `instance_tooltip` column in the `items` table
* If it exists, prioritize `instance_tooltip` in `tooltipDescription` field of `item` object
* Else, use default `tooltip_description` column (which is item-type based, not instance based)

E.g. Khavari family's laptop:
<img width="1422" alt="Screen Shot 2020-03-29 at 5 10 51 PM" src="https://user-images.githubusercontent.com/1973414/77865304-748a7500-71e2-11ea-835c-aeee60d7e314.png">
